### PR TITLE
fix: subject was not parsing from env or config

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,10 +107,15 @@ func main() {
 			return nil
 		}
 
-		option := models.Option{
-			Title:    &subject,
-			Subject:  &subject,
-			Priority: &priority,
+		option := models.Option{}
+
+		if ctx.IsSet("subject") {
+			option.Title = &subject
+			option.Subject = &subject
+		}
+
+		if ctx.IsSet("priority") {
+			option.Priority = &priority
 		}
 
 		if len(threadId) > 0 {


### PR DESCRIPTION
fix: subject was not parsing from env or config

subject for smtp and gotify was not parsing from .chatz.ini or env

as it was set "" in default so was skipping the check